### PR TITLE
Finish TODO: `HttpPeer::new_uds` error

### DIFF
--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -15,6 +15,7 @@
 //! Defines where to connect to and how to connect to a remote server
 
 use ahash::AHasher;
+use pingora_error::{BError, Error, ErrorType};
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hash::{Hash, Hasher};
@@ -407,8 +408,11 @@ impl HttpPeer {
     }
 
     /// Create a new [`HttpPeer`] with the given path to Unix domain socket and TLS settings.
-    pub fn new_uds(path: &str, tls: bool, sni: String) -> std::io::Result<Self> {
-        let addr = SocketAddr::Unix(UnixSocketAddr::from_pathname(Path::new(path))?);
+    pub fn new_uds(path: &str, tls: bool, sni: String) -> Result<Self, BError> {
+        let addr =
+            SocketAddr::Unix(UnixSocketAddr::from_pathname(Path::new(path)).map_err(|e| {
+                Error::because(ErrorType::Custom("invalid path"), "HttpPeer::new_uds", e)
+            })?);
         Ok(Self::new_from_sockaddr(addr, tls, sni))
     }
 

--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -407,9 +407,9 @@ impl HttpPeer {
     }
 
     /// Create a new [`HttpPeer`] with the given path to Unix domain socket and TLS settings.
-    pub fn new_uds(path: &str, tls: bool, sni: String) -> Self {
-        let addr = SocketAddr::Unix(UnixSocketAddr::from_pathname(Path::new(path)).unwrap()); //TODO: handle error
-        Self::new_from_sockaddr(addr, tls, sni)
+    pub fn new_uds(path: &str, tls: bool, sni: String) -> std::io::Result<Self> {
+        let addr = SocketAddr::Unix(UnixSocketAddr::from_pathname(Path::new(path))?);
+        Ok(Self::new_from_sockaddr(addr, tls, sni))
     }
 
     /// Create a new [`HttpPeer`] that uses a proxy to connect to the upstream IP and port

--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -15,7 +15,7 @@
 //! Defines where to connect to and how to connect to a remote server
 
 use ahash::AHasher;
-use pingora_error::{BError, Error, ErrorType};
+use pingora_error::{ErrorType, OrErr, Result};
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hash::{Hash, Hasher};
@@ -408,11 +408,11 @@ impl HttpPeer {
     }
 
     /// Create a new [`HttpPeer`] with the given path to Unix domain socket and TLS settings.
-    pub fn new_uds(path: &str, tls: bool, sni: String) -> Result<Self, BError> {
-        let addr =
-            SocketAddr::Unix(UnixSocketAddr::from_pathname(Path::new(path)).map_err(|e| {
-                Error::because(ErrorType::Custom("invalid path"), "HttpPeer::new_uds", e)
-            })?);
+    pub fn new_uds(path: &str, tls: bool, sni: String) -> Result<Self> {
+        let addr = SocketAddr::Unix(
+            UnixSocketAddr::from_pathname(Path::new(path))
+                .or_err(ErrorType::InternalError, "invalid path")?,
+        );
         Ok(Self::new_from_sockaddr(addr, tls, sni))
     }
 

--- a/pingora-proxy/tests/utils/server_utils.rs
+++ b/pingora-proxy/tests/utils/server_utils.rs
@@ -235,9 +235,11 @@ impl ProxyHttp for ExampleProxyHttp {
     ) -> Result<Box<HttpPeer>> {
         let req = session.req_header();
         if req.headers.contains_key("x-uds-peer") {
-            return Ok(Box::new(
-                HttpPeer::new_uds("/tmp/nginx-test.sock", false, "".to_string()).unwrap(),
-            ));
+            return Ok(Box::new(HttpPeer::new_uds(
+                "/tmp/nginx-test.sock",
+                false,
+                "".to_string(),
+            )?));
         }
         let port = req
             .headers

--- a/pingora-proxy/tests/utils/server_utils.rs
+++ b/pingora-proxy/tests/utils/server_utils.rs
@@ -235,11 +235,9 @@ impl ProxyHttp for ExampleProxyHttp {
     ) -> Result<Box<HttpPeer>> {
         let req = session.req_header();
         if req.headers.contains_key("x-uds-peer") {
-            return Ok(Box::new(HttpPeer::new_uds(
-                "/tmp/nginx-test.sock",
-                false,
-                "".to_string(),
-            )));
+            return Ok(Box::new(
+                HttpPeer::new_uds("/tmp/nginx-test.sock", false, "".to_string()).unwrap(),
+            ));
         }
         let port = req
             .headers


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [cloudflare/pingora#217](https://togithub.com/cloudflare/pingora/pull/217).



The original branch is fork-217-cospectrum/proxy/todo-new-uds-err