### PR TITLE
timeout: use SeqCst consistently to operate on the clock_watchdog variable

### DIFF
--- a/pingora-timeout/src/timer.rs
+++ b/pingora-timeout/src/timer.rs
@@ -132,7 +132,7 @@ impl TimerManager {
             std::thread::sleep(RESOLUTION_DURATION);
             let now = Instant::now() - self.zero;
             self.clock_watchdog
-                .store(now.as_secs() as i64, Ordering::Relaxed);
+                .store(now.as_secs() as i64, Ordering::SeqCst);
             if self.is_paused_for_fork() {
                 // just stop acquiring the locks, waiting for fork to happen
                 continue;


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [cloudflare/pingora#104](https://togithub.com/cloudflare/pingora/pull/104).



The original branch is fork-104-cppcoffee/timer