### PR TITLE
Fixes #261 - Better `Default` implementation for `Opt`

### DIFF
--- a/pingora-core/src/server/configuration/mod.rs
+++ b/pingora-core/src/server/configuration/mod.rs
@@ -118,7 +118,7 @@ impl Default for ServerConf {
 /// Command-line options
 ///
 /// Call `Opt::from_args()` to build this object from the process's command line arguments.
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Default)]
 #[clap(name = "basic", long_about = None)]
 pub struct Opt {
     /// Whether this server should try to upgrade from a running old server
@@ -160,15 +160,6 @@ pub struct Opt {
     /// See [`ServerConf`] for more details of the configuration file.
     #[clap(short, long, help = "The path to the configuration file.", long_help = None)]
     pub conf: Option<String>,
-}
-
-/// Create the default instance of Opt based on the current command-line args.
-/// This is equivalent to running `Opt::parse` but does not require the
-/// caller to have included the `clap::Parser`
-impl Default for Opt {
-    fn default() -> Self {
-        Opt::parse()
-    }
 }
 
 impl ServerConf {


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [cloudflare/pingora#272](https://togithub.com/cloudflare/pingora/pull/272).



The original branch is fork-272-palant/opt-default