### PR TITLE
Added `init_downstream_modules` phase allowing modules to be set up before startup

### DIFF
--- a/pingora-proxy/src/proxy_trait.rs
+++ b/pingora-proxy/src/proxy_trait.rs
@@ -40,6 +40,11 @@ pub trait ProxyHttp {
         ctx: &mut Self::CTX,
     ) -> Result<Box<HttpPeer>>;
 
+    /// Set up downstream modules.
+    ///
+    /// In this phase, users can add or configure modules before the server starts up.
+    fn init_downstream_modules(&self, _modules: &mut HttpModules) {}
+
     /// Handle the incoming request.
     ///
     /// In this phase, users can parse, validate, rate limit, perform access control and/or


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [cloudflare/pingora#284](https://togithub.com/cloudflare/pingora/pull/284).



The original branch is fork-284-palant/proxy-init